### PR TITLE
make lambda faster to avoid sf outbound message timeouts

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -76,7 +76,7 @@ Resources:
           App: !Ref App
       Description: parse salesforce outbound messages and put them in a queue
       Handler: com.gu.salesforce.messageHandler.Lambda::handleRequest
-      MemorySize: 512
+      MemorySize: 1536
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 300


### PR DESCRIPTION
We noticed that sf outbound messages have a timeout of 10 seconds, this lambda could take longer than that when large request are processed by a cold lambda.

I tested in code to determine execution times of the lambda when it's cold and it receives an xml with 100 contacts (the maximum sf will send).

Results:

| Memory (MB)        | Execution time (ms)  |
| ------------- |:-------------:| 
| 512    | 19091 | 
| 1024      | 10236 |     
| 1536 | 7258 -  8443 (multiple tests)|  

I tested a couple of times running the lambda cold with 1536 MB and it seems to stay under the 10 second limit. Regular execution times when the lambda is warm are around 1 - 2 seconds

@paulbrown1982 @jacobwinch 
