### PR TITLE
bump jackson versions again

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,8 @@ scalacOptions ++= Seq(
   "-Ywarn-dead-code"
 )
 
+val jacksonVersion = "2.9.8"
+
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
@@ -25,9 +27,9 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-simple" % "1.7.25",
   "com.typesafe.play" %% "play-json" % "2.6.0",
   "org.scala-lang.modules" % "scala-xml_2.11" % "1.0.6",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7",
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.9.7",
-  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7",
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "org.specs2" %% "specs2-core" % "3.9.4" % "test",
   "org.specs2" %% "specs2-matcher-extra" % "3.9.4" % "test",
   "org.specs2" % "specs2-mock_2.11" % "3.9.4" % "test",


### PR DESCRIPTION
It's that time again! 

https://app.snyk.io/org/the-guardian-cuu/project/cd7835f3-83d0-4916-9822-943ea7b4c07d/

Bumping jackson versions again because Snyk alerted us to do so. 

I deployed this change to CODE, then updated a contact in Salesforce UAT and then saw that the message in the `salesforce-outbound-messages-CODE` queue had a new message corresponding to that contact. Anything else to check @pvighi ?

 
