### PR TITLE
Include cloudformation stack update in deployments

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,6 +2,14 @@ stacks: [membership]
 regions: [eu-west-1]
 
 deployments:
+  cfn:
+    type: cloud-formation
+    parameters:
+      templatePath: cfn.yaml
+      cloudFormationStackName: salesforce-message-handler
+      cloudFormationStackByTags: false
+      prependStackToCloudFormationStackName: false
+      createStackIfAbsent: false  
   salesforce-message-handler:
     type: aws-lambda
     parameters:


### PR DESCRIPTION
This includes the cloudformation template as part of the Riffraff deployment recipe.
