### PR TITLE
Export cloudformation to standard location

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Subscriptions::Salesforce Message Handler"
-riffRaffArtifactResources += (file("cfn.yaml"), s"${name.value}-cfn/cfn.yaml")
+riffRaffArtifactResources += (file("cfn.yaml"), "cfn/cfn.yaml")
 
 CxfKeys.wsdls += Wsdl("sfOutboundMessages", (baseDirectory.value / "wsdl/salesforce-outbound-message.wsdl").getPath)
 


### PR DESCRIPTION
Usually, we expect to find the cloudformation template to be deployed to be in the build folder under cfn/cfn.yaml.
