### PR TITLE
Make jar deploy depend on cfn deploy

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -17,3 +17,4 @@ deployments:
       functionNames: [salesforce-message-handler-]
       fileName: salesforce-message-handler.jar
       prefixStack: false
+    dependencies: [cfn]


### PR DESCRIPTION
Currently, cloudformation and jar will deploy in parallel whereas we want the cloudformation to deploy first.