### PR TITLE
Bump SBT from 0.13.13 to 1.5.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,11 +51,16 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Subscriptions::Salesforce Message Handler"
 riffRaffArtifactResources += (file("cfn.yaml"), "cfn/cfn.yaml")
 
-CxfKeys.wsdls += Wsdl("sfOutboundMessages", (baseDirectory.value / "wsdl/salesforce-outbound-message.wsdl").getPath)
+cxfTarget := (sourceManaged.value / "cxf" / "sfOutboundMessages" / "main")
+cxfWsdls +=
+  Wsdl(
+    id = "",
+    wsdlFile = baseDirectory.value / "wsdl/salesforce-outbound-message.wsdl"
+  )
 
 //Having a merge strategy here is necessary as there is an conflict in the file contents for the jackson libs, there are two same versions with different contents.
 //As a result we're picking the first file found on the classpath - this may not be required if the contents match in a future release
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs@_*) => MergeStrategy.discard
   case x => MergeStrategy.first
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.8")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.7.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("com.github.stonexx.sbt" % "sbt-cxf" % "0.2.4")
+addSbtPlugin("io.dapas" % "sbt-cxf" % "0.2.0")


### PR DESCRIPTION
This bumps SBT and all SBT plugins to their latest versions.

The library that was being used to generate Java classes from WSDL is unsupported for SBT 1+ so I've swapped in another library that looks like it does the same thing.  The compiled class list looks the same with the new branch and the old main branch.
