### PR TITLE
Upgrade transient jackson dependencies due to vulnerability CVE-2020-36518

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ scalacOptions ++= Seq(
   "-Ywarn-dead-code"
 )
 
-val jacksonVersion = "2.13.1"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.1",
@@ -31,16 +30,27 @@ libraryDependencies ++= Seq(
   "org.specs2" %% "specs2-matcher-extra" % "4.13.2" % "test",
   "org.specs2" %% "specs2-mock" % "4.13.2" % "test",
   "org.hamcrest" % "hamcrest-all" % "1.3" % "test",
-  "org.mockito" % "mockito-all" % "1.10.19" % "test",
-  
-  // All the below are required to force aws libraries to use the latest version of jackson
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-  "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
-  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
-  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
-  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
+  "org.mockito" % "mockito-all" % "1.10.19" % "test"
 )
+
+/* required to bump jackson versions due to CVE-2020-36518 */ 
+val jacksonVersion         = "2.13.2"
+val jacksonDatabindVersion = "2.13.2.2"
+
+val jacksonDependencies = Seq(
+  "com.fasterxml.jackson.core"     % "jackson-core" %  jacksonVersion,
+  "com.fasterxml.jackson.core"     % "jackson-annotations" %  jacksonVersion,
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" %  jacksonVersion,
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" %  jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
+  "com.fasterxml.jackson.module"     % "jackson-module-parameter-names" % jacksonVersion,
+  "com.fasterxml.jackson.module"     %% "jackson-module-scala" % jacksonVersion,
+)
+
+dependencyOverrides ++= jacksonDependencies
+
+/* EOF jackson version overrides */
 
 enablePlugins(RiffRaffArtifact)
 

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -95,7 +95,7 @@ Resources:
           Description: Api to handle salesforce outbound messages
           Name: !Sub salesforce-message-handler-${Stage}
 
-  MessageHandlerApiResource:
+  MessageHandlerApiResource1:
       Type: AWS::ApiGateway::Resource
       Properties:
           RestApiId: !Ref MessageHandlerApi
@@ -108,7 +108,7 @@ Resources:
       Properties:
           AuthorizationType: NONE
           RestApiId: !Ref MessageHandlerApi
-          ResourceId: !Ref MessageHandlerApiResource
+          ResourceId: !Ref MessageHandlerApiResource1
           HttpMethod: POST
           Integration:
             Type: AWS_PROXY
@@ -117,7 +117,7 @@ Resources:
       DependsOn:
       - MessageHandlerApi
       - SalesforceMessageHandlerLambda
-      - MessageHandlerApiResource
+      - MessageHandlerApiResource1
 
   MessageHandlerApiStage:
     Type: AWS::ApiGateway::Stage

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -89,48 +89,48 @@ Resources:
               Principal: apigateway.amazonaws.com
           DependsOn: SalesforceMessageHandlerLambda
 
-  MessageHandlerApi1:
+  MessageHandlerApi:
       Type: "AWS::ApiGateway::RestApi"
       Properties:
           Description: Api to handle salesforce outbound messages
           Name: !Sub salesforce-message-handler-${Stage}
 
-  MessageHandlerApiResource1:
+  MessageHandlerApiResource:
       Type: AWS::ApiGateway::Resource
       Properties:
-          RestApiId: !Ref MessageHandlerApi1
-          ParentId: !GetAtt [MessageHandlerApi1, RootResourceId]
+          RestApiId: !Ref MessageHandlerApi
+          ParentId: !GetAtt [MessageHandlerApi, RootResourceId]
           PathPart: contact
-      DependsOn: MessageHandlerApi1
+      DependsOn: MessageHandlerApi
 
-  ContactMethod1:
+  ContactMethod:
       Type: AWS::ApiGateway::Method
       Properties:
           AuthorizationType: NONE
-          RestApiId: !Ref MessageHandlerApi1
-          ResourceId: !Ref MessageHandlerApiResource1
+          RestApiId: !Ref MessageHandlerApi
+          ResourceId: !Ref MessageHandlerApiResource
           HttpMethod: POST
           Integration:
             Type: AWS_PROXY
             IntegrationHttpMethod: POST
             Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SalesforceMessageHandlerLambda.Arn}/invocations
       DependsOn:
-      - MessageHandlerApi1
+      - MessageHandlerApi
       - SalesforceMessageHandlerLambda
-      - MessageHandlerApiResource1
+      - MessageHandlerApiResource
 
-  MessageHandlerApiStage1:
+  MessageHandlerApiStage:
     Type: AWS::ApiGateway::Stage
     Properties:
         Description: Stage for salesforce message handler API
-        RestApiId: !Ref MessageHandlerApi1
+        RestApiId: !Ref MessageHandlerApi
         DeploymentId: !Ref MessageHandlerAPIDeployment1
         StageName: !Sub ${Stage}
-    DependsOn: ContactMethod1
+    DependsOn: ContactMethod
 
   MessageHandlerAPIDeployment1:
     Type: AWS::ApiGateway::Deployment
     Properties:
         Description: Deploys the message handler API into an environment/stage
-        RestApiId: !Ref MessageHandlerApi1
-    DependsOn: ContactMethod1
+        RestApiId: !Ref MessageHandlerApi
+    DependsOn: ContactMethod

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -89,7 +89,7 @@ Resources:
               Principal: apigateway.amazonaws.com
           DependsOn: SalesforceMessageHandlerLambda
 
-  MessageHandlerApi:
+  MessageHandlerApi1:
       Type: "AWS::ApiGateway::RestApi"
       Properties:
           Description: Api to handle salesforce outbound messages
@@ -98,16 +98,16 @@ Resources:
   MessageHandlerApiResource1:
       Type: AWS::ApiGateway::Resource
       Properties:
-          RestApiId: !Ref MessageHandlerApi
-          ParentId: !GetAtt [MessageHandlerApi, RootResourceId]
+          RestApiId: !Ref MessageHandlerApi1
+          ParentId: !GetAtt [MessageHandlerApi1, RootResourceId]
           PathPart: contact
-      DependsOn: MessageHandlerApi
+      DependsOn: MessageHandlerApi1
 
-  ContactMethod:
+  ContactMethod1:
       Type: AWS::ApiGateway::Method
       Properties:
           AuthorizationType: NONE
-          RestApiId: !Ref MessageHandlerApi
+          RestApiId: !Ref MessageHandlerApi1
           ResourceId: !Ref MessageHandlerApiResource1
           HttpMethod: POST
           Integration:
@@ -115,22 +115,22 @@ Resources:
             IntegrationHttpMethod: POST
             Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SalesforceMessageHandlerLambda.Arn}/invocations
       DependsOn:
-      - MessageHandlerApi
+      - MessageHandlerApi1
       - SalesforceMessageHandlerLambda
       - MessageHandlerApiResource1
 
-  MessageHandlerApiStage:
+  MessageHandlerApiStage1:
     Type: AWS::ApiGateway::Stage
     Properties:
         Description: Stage for salesforce message handler API
-        RestApiId: !Ref MessageHandlerApi
-        DeploymentId: !Ref MessageHandlerAPIDeployment
+        RestApiId: !Ref MessageHandlerApi1
+        DeploymentId: !Ref MessageHandlerAPIDeployment1
         StageName: !Sub ${Stage}
-    DependsOn: ContactMethod
+    DependsOn: ContactMethod1
 
-  MessageHandlerAPIDeployment:
+  MessageHandlerAPIDeployment1:
     Type: AWS::ApiGateway::Deployment
     Properties:
         Description: Deploys the message handler API into an environment/stage
-        RestApiId: !Ref MessageHandlerApi
-    DependsOn: ContactMethod
+        RestApiId: !Ref MessageHandlerApi1
+    DependsOn: ContactMethod1


### PR DESCRIPTION
## What does this change?

Transient Jackson dependencies will be upgraded to a version that fixes CVE-2020-36518.

## How to test

You can run `sbt dependencyTree` and hunt through the output, but I personally:
1. Added `addDependencyTreePlugin` to `plugins.sbt`
2. Ran `sbt` and then `whatDependsOn com.fasterxml.jackson.core jackson-databind` (for example)

