### PR TITLE
Removing dependency on com.amazonaws:aws-lambda-java-log4j cause it introduces a snyk vulnerability.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,6 @@ scalacOptions ++= Seq(
 
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.1",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
   "com.amazonaws" % "aws-java-sdk-sqs" % "1.12.150",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.12.150",


### PR DESCRIPTION
Removing dependency on com.amazonaws:aws-lambda-java-log4j cause it introduces a snyk vulnerability.